### PR TITLE
Add support for an empty new line at the end of the daily file

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -39,7 +39,16 @@ export default class ListModified extends Plugin {
 
 			if (tags[0] !== '' && !this.fileMeetsTagRequirements(currentFile, tags)) return
 
-			await this.app.vault.append(dailyFile, '\n' + resolvedOutputFormat)
+			const contents: string = await this.app.vault.cachedRead(dailyFile)
+
+			// If the daily file ends with a new line character, put the new
+			// modified file link onto that line and add a new line. Otherwise,
+			// add a new line first, then append the new modified file link.
+			if (contents.slice(-1) == '\n') {
+				await this.app.vault.append(dailyFile, resolvedOutputFormat + '\n')
+			} else {
+				await this.app.vault.append(dailyFile, '\n' + resolvedOutputFormat)
+			}
 		}))
 
 		this.addSettingTab(new ListModifiedSettingTab(this.app, this))

--- a/main.ts
+++ b/main.ts
@@ -39,15 +39,15 @@ export default class ListModified extends Plugin {
 
 			if (tags[0] !== '' && !this.fileMeetsTagRequirements(currentFile, tags)) return
 
-			const contents: string = await this.app.vault.cachedRead(dailyFile)
+			const contents: string = await this.app.vault.read(dailyFile)
 
 			// If the daily file ends with a new line character, put the new
 			// modified file link onto that line and add a new line. Otherwise,
-			// add a new line first, then append the new modified file link.
+			// add a new line first, then add the new modified file link.
 			if (contents.slice(-1) == '\n') {
-				await this.app.vault.append(dailyFile, resolvedOutputFormat + '\n')
+				await this.app.vault.modify(dailyFile, contents + resolvedOutputFormat + '\n')
 			} else {
-				await this.app.vault.append(dailyFile, '\n' + resolvedOutputFormat)
+				await this.app.vault.modify(dailyFile, contents + '\n' + resolvedOutputFormat)
 			}
 		}))
 


### PR DESCRIPTION
Thank you for making this plugin. It is working great!

However, I prefer to have my files end with a new line (I guess it's a habit from common programming style standards).

Apologies if anything here is written wrong. I have very little experience with typescript and no experience with the Obsidian API. However, I did compile this and it works as far as I can tell.

## Current Behavior
Currently, the plugin simply appends the modified file link to the end of the daily note whether there is a new line character already there or not.

2022-03-28.md
```
# Example Daily Note
...

## Modified Files
- [[Foo Note]]

```

and after modifying a file:
```
# Example Daily Note
...

## Modified Files
- [[Foo Note]]

- [[Bar Note]]
```

## New Behavior
This pull request simply adds a check to see if a new line character already exists at the end of the daily file. If it does, it places the link to the modified file on that line and adds a new end of file new line. If it doesn't find a new line at the end of the file, it returns to current behavior.

2022-03-28.md
```
# Example Daily Note
...

## Modified Files
- [[Foo Note]]

```

and after modifying a file:
```
# Example Daily Note
...

## Modified Files
- [[Foo Note]]
- [[Bar Note]]

```

## Other Potential Solutions
A more complicated to implement, but potentially nicer for the user, solution would be to have the user specify a heading that the modified files can be listed under instead of appending them to the end of the file. I don't know the Obsidian API enough to implement that myself, but I'd love to see that feature added.