### PR TITLE
Add "Time format" setting and "[[mtime]]" placeholder

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const DEFAULT_SETTINGS: ListModifiedSettings = {
 	// FORMATTING
 	outputFormat: "- [[link]]",
 	appendSpaceAfterHeadings: false,
+	timeFormat: "YYYY-MM-DD",
 
 	// LOG NOTE
 	autoCreateLogNote: true,

--- a/src/io/settingsTab.ts
+++ b/src/io/settingsTab.ts
@@ -74,7 +74,7 @@ export class ListModifiedSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Output Format")
 			.setDesc(
-				"The format to output added links. Use [[link]] as a placeholder to represent a link, [[name]] for file name, [[tags]], [[ctime]] for created time."
+				"The format to output added links. Use [[link]] as a placeholder to represent a link, [[name]] for file name, [[tags]], [[ctime]] for created time, [[mtime]] for modified time."
 			)
 			.addText((text) =>
 				text
@@ -85,6 +85,21 @@ export class ListModifiedSettingTab extends PluginSettingTab {
 						await saveSettingsAndWriteTrackedFiles();
 					})
 			);
+
+		new Setting(containerEl)
+			.setName("Time Format")
+			.setDesc(
+				"Format for the [[ctime]] or [[mtime]] placeholders"
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("e.g. YYYY-MM-DD or HH:mm")
+					.setValue(settings.timeFormat)
+					.onChange(async (value) => {
+						settings.timeFormat = value;
+						await saveSettingsAndWriteTrackedFiles();
+					})
+			)
 
 		new Setting(containerEl)
 			.setName("Append Space After Headings")

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface ListModifiedSettings {
 	// FORMATTING
 	outputFormat: string;
 	appendSpaceAfterHeadings: boolean;
+	timeFormat: string;
 
 	// LOG NOTE
 	autoCreateLogNote: boolean;

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -20,7 +20,8 @@ export function getFormattedOutput(path: string): string {
 		return "- " + path;
 	}
 
-	return getSettings()
+	const settings = getSettings()
+	return settings
 		.outputFormat.replace(
 			"[[link]]",
 			this.app.fileManager.generateMarkdownLink(
@@ -35,7 +36,8 @@ export function getFormattedOutput(path: string): string {
 				.map((tag) => "\\" + tag)
 				.join(", ")
 		)
-		.replace(/\[\[ctime]]/g, moment(file.stat.ctime).format("YYYY-MM-DD"));
+		.replace(/\[\[ctime]]/g, moment(file.stat.ctime).format(settings.timeFormat))
+		.replace(/\[\[mtime]]/g, moment(file.stat.mtime).format(settings.timeFormat));
 }
 
 export function getFormattedHeading(heading: string) {


### PR DESCRIPTION
Hi :slightly_smiling_face: 
Thank you for the great plugin!  
I found confusing that regardless of granularity selected (e.g. even for daily notes), the [[ctime]] format is always YYYY-MM-DD + it only shows note's created time (which may be created many months ago, but modified today), so I've added a setting for specifying the time format and also added [[mtime]] placeholder similar to [[ctime]], but for note's modified time. Both placeholders use the same format defined in the settings. Default value for the format is YYYY-MM-DD